### PR TITLE
fix throwing in executor

### DIFF
--- a/index.js
+++ b/index.js
@@ -272,7 +272,12 @@ function wrapPromise() {
     var context, args;
     var promise = new Promise(wrappedExecutor);
     promise.__proto__ = wrappedPromise.prototype;
-    executor.apply(context, args);
+
+    try {
+      executor.apply(context, args);
+    } catch (err) {
+      args[1](err)
+    }
 
     return promise;
 

--- a/test/native-promises.tap.js
+++ b/test/native-promises.tap.js
@@ -1356,6 +1356,50 @@ test('multi catch with promise', function(t) {
   }
 });
 
+test('throw in executor', function(t) {
+  var listener = addListner();
+
+  var promise = new Promise(function unsafe() {
+    listener.currentName = 'throw';
+    throw 10;
+  });
+
+  promise.catch(function(val) {
+    t.equal(val, 10, 'should match thrown value')
+    if (listener.root.children.length === 2) {
+      expected.children.splice(1, 0, {
+        name: 'throw',
+        children: [],
+        before: 0,
+        after: 0,
+        error: 0
+      })
+    }
+
+    t.deepEqual(listener.root, expected);
+    t.end();
+  });
+
+  process.removeAsyncListener(listener.listener);
+
+  var expected = {
+    name: 'root',
+    children: [
+      {
+        name: 'throw',
+        children: [
+        ],
+        before: 1,
+        after: 0,
+        error: 0
+      }
+    ],
+    before: 0,
+    after: 0,
+    error: 0
+  }
+});
+
 function addListner() {
   var listener = process.addAsyncListener({
     create: create,


### PR DESCRIPTION
I also wrote a bit about how this works but was not sure if I should add it.... 

I am not very good at documentation or writing things that are easy to follow.




Native promises use the microtask queue to make all callbacks run asynchonously to avoid [zalgo](http://blog.izs.me/post/59142742143/designing-apis-for-asynchrony) issues. Since the microtask queue is not exposed externally, promises need to be modified in a fairly invasive and complex way.
The async boundry in promises that must be patched is between the fullfillment of the promise and the execution of any callback that is waiting for that fullfillment to happen.  This means that we need to trigger a `create` when `accept` or `reject` is called and trigger `before`, `after` and `error` handlers around the callback execution. There may be multiple callbacks for each fullfilled promise, so handlers
will behave similar to setInterval where there may be multiple `before` `after` and `error` calls for each `create` call.

Aync lister monkeypatching has one basic entry point: `wrapCallback`. `wrapCallback` should be called when `create` should be triggered and be passed a function to wrap, which will execute the body of the async work. The `accept` and `reject` calls can be modified fairly easily to call `wrapCallback`, but at the time of `accept` and `reject` all the work to be done on fullfillment may not be defined, since a call to `then`, `chain` or `fetch` can be made even after the promise has been fullfilled.  To get around this, we create a placeholder function which will call a function passed into it, since the call to the main work is being made from within the wrapped function, async-listener will work
correctly.

There is another complication with monkeypatching Promises. Calls to `then`, `chain` and `catch` each create new Promises that are fullfilled internally in different ways depending on the return value of the
callback.  When the callback return a Promise, the new Promise is resolved asynchonously after the returned Promise has been also been resolved. When something other than a promise is resolved the accept call for the new Promise is put in the microtask queue and asynchronously resolved.
Then must be wrapped so that its returned promise has a wrapper that can be used to invoke further continuations.  This wrapper cannot be created until after the callback has run, since the callback may return either a promise or another value.  Fortunatly we already have a wrapper function around the callback we can use (the wrapper created by `accept` or `reject`).  
By adding an additional argument to this wrapper, we can pass in the returned promise so it can have its own wrapper appended. the wrapper function can the call the callback, and take action based
on the return value.  If a promise is returned, the new Promise can proxy the returned Promise's wrapper (this wrapper may not exist yet, but will by the time the wrapper needs to be invoked). Otherwise, Otherwise, a new wrapper can be create the same way as in `accept` and `reject`. Since this wrapper is created synchronously within another wrapper, it will properly appear as a continuation from within the callback.